### PR TITLE
nth-check version update - fix security alert #3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4469,12 +4469,12 @@
         "boolbase": "^1.0.0",
         "css-what": "^3.2.1",
         "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "nth-check": "^2.0.1"
       },
       "dependencies": {
         "nth-check": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
           "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
           "requires": {
             "boolbase": "~1.0.0"


### PR DESCRIPTION
As recommended by Trivy scanner, the version of this dependency is upgraded to 2.0.1 @pmatchettIntelius @waynejohnn 